### PR TITLE
Update Db.php

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -567,10 +567,10 @@ abstract class DbCore
 		if ($use_cache && $this->is_cache_enabled && $array)
 		{
 			$this->last_query_hash = Tools::encryptIV($sql);
-			if (($result = Cache::getInstance()->get($this->last_query_hash)) !== false)
+			if (Cache::getInstance()->exists($this->last_query_hash) !== false)
 			{
 				$this->last_cached = true;
-				return $result;
+				return Cache::getInstance()->get($this->last_query_hash);
 			}
 		}
 
@@ -624,10 +624,10 @@ abstract class DbCore
 		if ($use_cache && $this->is_cache_enabled)
 		{
 			$this->last_query_hash = Tools::encryptIV($sql);
-			if (($result = Cache::getInstance()->get($this->last_query_hash)) !== false)
+			if (Cache::getInstance()->exists($this->last_query_hash) !== false)
 			{
 				$this->last_cached = true;
-				return $result;
+				return Cache::getInstance()->get($this->last_query_hash);
 			}
 		}
 


### PR DESCRIPTION
Cache::getInstance()->exists($this->last_query_hash) is right
Because some sql value is indeed false, (empty value), which generate conflict and we judge bug!
so You can not use "Cache::getInstance()->get($this->last_query_hash)" as a basis for judgment